### PR TITLE
feat: enable time-range highlighting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -59,9 +59,10 @@
       </svg>
     </button>
     <main>
-      <section id="chartSection" class="chart-section" aria-labelledby="chartHeader">
+        <section id="chartSection" class="chart-section" aria-labelledby="chartHeader">
         <div id="debtTicker" class="mb-4 ticker" aria-live="polite">$0.00</div>
         <svg id="debtChart" role="img" aria-label="U.S. National Debt Over Time Chart"></svg>
+        <button id="resetZoom" class="mt-2 px-4 py-2 border-2 border-black rounded bg-white text-black dark:bg-black dark:text-green-500 dark:border-green-500">Reset Zoom</button>
       </section>
       <section id="debtInWords" class="debt-in-words">
         <h2 id="debtInWordsHeader">The Debt in Full</h2>

--- a/src/chart.js
+++ b/src/chart.js
@@ -1,6 +1,7 @@
-import * as d3 from 'd3'; // Add this import
+import * as d3 from 'd3';
 import { isMobile, getSvgHeight } from './utils.js';
-import { getTimeFrame } from './debtData.js'; // Ensure this is imported too
+import { getTimeFrame, setCustomTimeFrame } from './debtData.js';
+import { updateDebtInWords, updateAnalysis } from './uiUpdates.js';
 
 export function drawLineChartAndTicker(data) {
     const svg = d3.select('#debtChart');
@@ -104,4 +105,21 @@ export function drawLineChartAndTicker(data) {
                 return offset;
             };
         });
+
+    const brush = d3.brushX()
+        .extent([[0, 0], [width, chartHeight]])
+        .on('end', event => {
+            if (!event.selection) return;
+            const [x0, x1] = event.selection;
+            const start = x.invert(x0);
+            const end = x.invert(x1);
+            setCustomTimeFrame(start, end);
+            drawLineChartAndTicker(data);
+            updateDebtInWords(data);
+            updateAnalysis(data);
+        });
+
+    g.append('g')
+        .attr('class', 'brush')
+        .call(brush);
 }

--- a/src/debtData.js
+++ b/src/debtData.js
@@ -1,5 +1,11 @@
 import * as d3 from 'd3';
 
+let customTimeFrame = null;
+
+export function setCustomTimeFrame(startDate, endDate) {
+    customTimeFrame = startDate && endDate ? { startDate, endDate } : null;
+}
+
 export async function fetchDebtData() {
     const apiURL = 'https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v2/accounting/od/debt_to_penny?fields=record_date,tot_pub_debt_out_amt&sort=-record_date&page[size]=10000';
     try {
@@ -25,6 +31,7 @@ export async function fetchDebtData() {
 }
 
 export function getTimeFrame(data) {
+    if (customTimeFrame) return customTimeFrame;
     const minDate = d3.min(data, d => d.date);
     const maxDate = d3.max(data, d => d.date);
     const minYear = minDate.getFullYear();

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,15 @@
-import * as d3 from 'd3'; // Add this import
+import * as d3 from 'd3';
 import './styles.css';
-import { fetchDebtData } from './debtData.js';
+import { fetchDebtData, setCustomTimeFrame } from './debtData.js';
 import { drawLineChartAndTicker } from './chart.js';
 import { updateDebtInWords, updateAnalysis } from './uiUpdates.js';
 import { showPreloader } from './preloader.js';
 import { initializeTheme } from './theme.js';
 import { debounce, getCookie, setCookie } from './utils.js';
+let debtData = [];
 
 async function init() {
-    const debtData = await fetchDebtData();
+    debtData = await fetchDebtData();
     initializeTheme();
 
     if (!getCookie('visited')) {
@@ -25,16 +26,22 @@ async function init() {
             d3.select('#debtTicker').text('Error loading data');
         }
     }
+
+    const resetBtn = document.getElementById('resetZoom');
+    resetBtn.addEventListener('click', () => {
+        setCustomTimeFrame(null, null);
+        drawLineChartAndTicker(debtData);
+        updateDebtInWords(debtData);
+        updateAnalysis(debtData);
+    });
 }
 
 function handleResize() {
-    fetchDebtData().then(data => {
-        if (data.length > 0) {
-            drawLineChartAndTicker(data);
-            updateDebtInWords(data);
-            updateAnalysis(data);
-        }
-    });
+    if (debtData.length > 0) {
+        drawLineChartAndTicker(debtData);
+        updateDebtInWords(debtData);
+        updateAnalysis(debtData);
+    }
 }
 
 init();

--- a/src/styles.css
+++ b/src/styles.css
@@ -102,6 +102,16 @@ a:hover {
     @apply dark:fill-gray-200;
 }
 
+.brush .selection {
+    fill: rgba(0, 0, 0, 0.3);
+    stroke: rgba(0, 0, 0, 0.8);
+}
+
+.dark .brush .selection {
+    fill: rgba(34, 197, 94, 0.3);
+    stroke: rgba(34, 197, 94, 0.8);
+}
+
 .glow {
     @apply drop-shadow-[0_0_10px_red];
     @apply dark:drop-shadow-[0_0_10px_rgb(34,197,94)];


### PR DESCRIPTION
## Summary
- enable drag-to-highlight on the debt chart using d3 brush
- track custom time frame and allow resetting
- style brush selection and add reset button

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689375428e9c83259b0ca9d01604fc6e