### PR TITLE
Improve chart date range handling and reset button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -61,8 +61,10 @@
     <main>
         <section id="chartSection" class="chart-section" aria-labelledby="chartHeader">
         <div id="debtTicker" class="mb-4 ticker" aria-live="polite">$0.00</div>
-        <svg id="debtChart" role="img" aria-label="U.S. National Debt Over Time Chart"></svg>
-        <button id="resetZoom" class="mt-2 px-4 py-2 border-2 border-black rounded bg-white text-black dark:bg-black dark:text-green-500 dark:border-green-500">Reset Zoom</button>
+        <div id="chartContainer" class="relative">
+          <svg id="debtChart" role="img" aria-label="U.S. National Debt Over Time Chart"></svg>
+          <button id="resetZoom" class="hidden absolute top-2 left-2 px-4 py-2 border-2 border-black rounded bg-white text-black dark:bg-black dark:text-green-500 dark:border-green-500">Reset Date Range</button>
+        </div>
       </section>
       <section id="debtInWords" class="debt-in-words">
         <h2 id="debtInWordsHeader">The Debt in Full</h2>

--- a/src/chart.js
+++ b/src/chart.js
@@ -48,6 +48,11 @@ export async function drawLineChartAndTicker(data) {
     const { startDate, endDate } = getTimeFrame(data);
     const filteredData = data.filter(d => d.date >= startDate && d.date <= endDate);
 
+    if (filteredData.length < 2) {
+        console.warn('Select at least two years of data.');
+        return;
+    }
+
     const x = d3.scaleTime().domain([startDate, endDate]).range([0, width]);
     const y = d3.scaleLinear()
         .domain([d3.min(filteredData, d => d.debt) * 0.95, d3.max(filteredData, d => d.debt) * 1.05])
@@ -211,7 +216,15 @@ export async function drawLineChartAndTicker(data) {
             const [x0, x1] = event.selection;
             const start = x.invert(x0);
             const end = x.invert(x1);
+            const startYear = start.getFullYear();
+            const endYear = end.getFullYear();
+            if (endYear - startYear < 1) {
+                alert('Please select at least two years.');
+                d3.select('#resetZoom').classed('hidden', true);
+                return;
+            }
             setCustomTimeFrame(start, end);
+            d3.select('#resetZoom').classed('hidden', false);
             drawLineChartAndTicker(data);
             updateDebtInWords(data);
             updateAnalysis(data);

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ async function init() {
         drawLineChartAndTicker(debtData);
         updateDebtInWords(debtData);
         updateAnalysis(debtData);
+        resetBtn.classList.add('hidden');
     });
 }
 

--- a/src/uiUpdates.js
+++ b/src/uiUpdates.js
@@ -37,6 +37,11 @@ export function updateAnalysis(data) {
         yearlyData[yr] = d.debt;
     });
     const years = Object.keys(yearlyData).map(Number).sort((a, b) => a - b);
+    if (years.length < 2) {
+        d3.select('#analysisText').text('Select at least two years to view analysis.');
+        return;
+    }
+
     const startYear = years[0];
     const endYear = years[years.length - 1];
     const startDebt = yearlyData[startYear];


### PR DESCRIPTION
## Summary
- Move reset control inside chart, rename to "Reset Date Range" and show only after selection
- Add validation for brushed date range and hide reset on invalid selections
- Prevent analysis errors when fewer than two years are selected

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893e3e32d588325a810970310a1bf95