### PR TITLE
Display selected date range in chart title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -63,7 +63,7 @@
         <div id="debtTicker" class="mb-4 ticker" aria-live="polite">$0.00</div>
         <div id="chartContainer" class="relative">
           <svg id="debtChart" role="img" aria-label="U.S. National Debt Over Time Chart"></svg>
-          <button id="resetZoom" class="hidden absolute top-2 left-2 px-4 py-2 border-2 border-black rounded bg-white text-black dark:bg-black dark:text-green-500 dark:border-green-500">Reset Date Range</button>
+          <button id="resetZoom" class="hidden absolute bottom-2 right-2 px-4 py-2 border-2 border-black rounded bg-white text-black dark:bg-black dark:text-green-500 dark:border-green-500">Reset Date Range</button>
         </div>
       </section>
       <section id="debtInWords" class="debt-in-words">

--- a/src/chart.js
+++ b/src/chart.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 import { isMobile, getSvgHeight } from './utils.js';
-import { getTimeFrame, setCustomTimeFrame } from './debtData.js';
+import { getTimeFrame, setCustomTimeFrame, isCustomTimeFrame } from './debtData.js';
 import { updateDebtInWords, updateAnalysis } from './uiUpdates.js';
 
 let eventsCache = null;
@@ -60,6 +60,10 @@ export async function drawLineChartAndTicker(data) {
 
     svg.style('opacity', 0).transition().duration(1000).style('opacity', 1);
 
+    const chartTitle = isCustomTimeFrame()
+        ? `U.S. National Debt ${startDate.getFullYear()}-${endDate.getFullYear()}`
+        : 'U.S. National Debt Over Time';
+
     svg.append('text')
         .attr('x', margin.left + width / 2)
         .attr('y', margin.top / 2)
@@ -67,7 +71,7 @@ export async function drawLineChartAndTicker(data) {
         .attr('font-family', 'Press Start 2P')
         .attr('font-size', isMobile() ? '1rem' : '1.2rem')
         .attr('class', 'fill-black dark:fill-green-500')
-        .text('U.S. National Debt Over Time');
+        .text(chartTitle);
 
     g.append('g')
         .attr('transform', `translate(0,${chartHeight})`)

--- a/src/debtData.js
+++ b/src/debtData.js
@@ -6,6 +6,10 @@ export function setCustomTimeFrame(startDate, endDate) {
     customTimeFrame = startDate && endDate ? { startDate, endDate } : null;
 }
 
+export function isCustomTimeFrame() {
+    return customTimeFrame !== null;
+}
+
 export async function fetchDebtData() {
     const apiURL = 'https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v2/accounting/od/debt_to_penny?fields=record_date,tot_pub_debt_out_amt&sort=-record_date&page[size]=10000';
     try {


### PR DESCRIPTION
## Summary
- show selected date range in chart header
- reposition reset date range button to chart's bottom-right corner

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68949b5a04bc83258d154a1827804e4a