### PR TITLE
Improve modal focus for accessibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -80,7 +80,7 @@
       <a href="https://github.com/nathan-wallace/us-national-debt-tracker" target="_blank" rel="noopener noreferrer" class="mx-[10px]">GitHub Repo</a>
     </footer>
   </div>
-  <div id="eventModal" class="fixed inset-0 bg-black/60 hidden flex items-center justify-center z-[1000]" role="dialog" aria-modal="true">
+  <div id="eventModal" class="fixed inset-0 bg-black/60 hidden flex items-center justify-center z-[1000]" role="dialog" aria-modal="true" aria-labelledby="eventTitle" aria-describedby="eventDescription" tabindex="-1">
     <div class="bg-white dark:bg-black text-black dark:text-green-500 p-4 rounded max-w-md mx-4">
       <h3 id="eventTitle" class="font-bold mb-2"></h3>
       <p id="eventDescription" class="mb-2"></p>

--- a/src/chart.js
+++ b/src/chart.js
@@ -18,17 +18,29 @@ const modal = d3.select('#eventModal');
 const modalTitle = d3.select('#eventTitle');
 const modalDesc = d3.select('#eventDescription');
 const modalSource = d3.select('#eventSource');
+const modalClose = d3.select('#modalClose');
+let lastFocusedElement = null;
 
-d3.select('#modalClose').on('click', () => modal.classed('hidden', true));
+function closeModal() {
+    modal.classed('hidden', true);
+    if (lastFocusedElement) lastFocusedElement.focus();
+}
+
+modalClose.on('click', closeModal);
 modal.on('click', event => {
-    if (event.target === modal.node()) modal.classed('hidden', true);
+    if (event.target === modal.node()) closeModal();
+});
+d3.select(window).on('keydown', event => {
+    if (event.key === 'Escape' && !modal.classed('hidden')) closeModal();
 });
 
 function showEventModal(evt) {
     modalTitle.text(evt.title);
     modalDesc.text(evt.description);
     modalSource.attr('href', evt.url);
+    lastFocusedElement = document.activeElement;
     modal.classed('hidden', false);
+    modal.node().focus();
 }
 
 export async function drawLineChartAndTicker(data) {


### PR DESCRIPTION
## Summary
- manage focus when the event modal opens and closes so keyboard users aren't left behind
- label the modal and make it programmatically focusable for screen readers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68949e2a4b048325b2995ddc1d152917