### PR TITLE
Avoid chart redraw on mobile scroll or zoom

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import { showPreloader } from './preloader.js';
 import { initializeTheme } from './theme.js';
 import { debounce, getCookie, setCookie } from './utils.js';
 let debtData = [];
+let lastWidth = window.innerWidth;
 
 async function init() {
     debtData = await fetchDebtData();
@@ -38,6 +39,10 @@ async function init() {
 }
 
 function handleResize() {
+    const width = window.innerWidth;
+    const scale = window.visualViewport ? window.visualViewport.scale : 1;
+    if (width === lastWidth || scale !== 1) return;
+    lastWidth = width;
     if (debtData.length > 0) {
         drawLineChartAndTicker(debtData);
         updateDebtInWords(debtData);
@@ -47,3 +52,4 @@ function handleResize() {
 
 init();
 window.addEventListener('resize', debounce(handleResize, 200));
+


### PR DESCRIPTION
## Summary
- prevent unnecessary chart redraws on mobile by ignoring resize events where viewport width is unchanged or page is being zoomed

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6894cc1485d88325a0bd91db5da38e49