### PR TITLE
Improve mobile chart view and reset control

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,9 +62,9 @@
     <main>
         <section id="chartSection" class="chart-section" aria-labelledby="chartHeader">
         <div id="debtTicker" class="mb-4 ticker" aria-live="polite">$0.00</div>
+          <button id="resetZoom" class="hidden mb-2 ml-auto block px-2 py-1 text-xs border border-black rounded bg-white text-black dark:bg-black dark:text-green-500 dark:border-green-500">Reset</button>
         <div id="chartContainer" class="relative">
           <svg id="debtChart" role="img" aria-label="U.S. National Debt Over Time Chart"></svg>
-          <button id="resetZoom" class="hidden absolute bottom-2 right-2 px-4 py-2 border-2 border-black rounded bg-white text-black dark:bg-black dark:text-green-500 dark:border-green-500">Reset Date Range</button>
         </div>
       </section>
       <section id="debtInWords" class="debt-in-words">

--- a/src/chart.js
+++ b/src/chart.js
@@ -49,7 +49,7 @@ export async function drawLineChartAndTicker(data) {
     svg.attr('height', height);
 
     const margin = isMobile()
-        ? { top: 40, right: 20, bottom: 80, left: 50 }
+        ? (window.innerHeight < 400 ? { top: 20, right: 20, bottom: 50, left: 40 } : { top: 40, right: 20, bottom: 80, left: 50 })
         : { top: 60, right: 60, bottom: 100, left: 80 };
     const width = parseInt(svg.style('width')) - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,7 +4,7 @@
 
 @layer base {
     html {
-        @apply h-screen w-screen overflow-x-hidden antialiased;
+        @apply min-h-screen w-screen overflow-x-hidden antialiased;
     }
 
     body {
@@ -35,7 +35,7 @@
     }
 
     #debtChart {
-        @apply rounded-[15px] w-full h-[clamp(250px,80vh,400px)] block;
+        @apply rounded-[15px] w-full block;
     }
 
     .debt-in-words {
@@ -172,12 +172,7 @@ a:hover {
 @media (max-width: 640px) {
     #debtTicker {
         @apply text-[clamp(1.2rem,3.5vw,2rem)];
-    }
-    
-    .chart-section #debtChart {
-        @apply h-[250px];
-    }
-    
+    }    
     .debt-in-words p,
     .analysis p {
         @apply text-[clamp(0.75rem,1.5vw,0.95rem)];

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,7 +51,7 @@ export function numberToWords(num) {
 
 export const isMobile = () => window.innerWidth <= 640;
 
-export const getSvgHeight = () => (isMobile() ? 250 : 400);
+export const getSvgHeight = () => (isMobile() ? Math.max(180, Math.min(window.innerHeight * 0.6, 300)) : 400);
 
 export function getCookie(name) {
     const value = `; ${document.cookie}`;


### PR DESCRIPTION
## Summary
- Adjust chart height and margins for small screens
- Move and shrink "Reset" button for better accessibility

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895fefca820832582b6b0e1193a1224