### PR TITLE
Place reset control in chart's top-left corner

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,8 +62,8 @@
     <main>
         <section id="chartSection" class="chart-section" aria-labelledby="chartHeader">
         <div id="debtTicker" class="mb-4 ticker" aria-live="polite">$0.00</div>
-          <button id="resetZoom" class="hidden mb-2 ml-auto block px-2 py-1 text-xs border border-black rounded bg-white text-black dark:bg-black dark:text-green-500 dark:border-green-500">Reset</button>
         <div id="chartContainer" class="relative">
+          <button id="resetZoom" class="hidden absolute top-2 left-2 z-10 px-2 py-1 text-xs border border-black rounded bg-white text-black dark:bg-black dark:text-green-500 dark:border-green-500">Reset</button>
           <svg id="debtChart" role="img" aria-label="U.S. National Debt Over Time Chart"></svg>
         </div>
       </section>

--- a/src/chart.js
+++ b/src/chart.js
@@ -54,6 +54,10 @@ export async function drawLineChartAndTicker(data) {
     const width = parseInt(svg.style('width')) - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;
 
+    d3.select('#resetZoom')
+        .style('top', `${margin.top + 8}px`)
+        .style('left', `${margin.left + 8}px`);
+
     svg.selectAll('*').remove();
     const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
 


### PR DESCRIPTION
## Summary
- Reposition Reset button inside chart area, aligned with x-axis margin.
- Dynamically offset Reset button using chart margins so it appears at the chart's top-left.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896022d807883259f0c57104bca5338