### PR TITLE
fix: remove redundant stylesheet link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,6 @@
   <link rel="icon" type="image/x-icon" href="https://nathan-wallace.github.io/the-national-debt/images/favicon.ico">
   
   <title>The National Debt</title>
-  <link rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" media="print" onload="this.media='all'">


### PR DESCRIPTION
## Summary
- remove unnecessary styles.css link from index.html to prevent 404/MIME errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689603d8a744832588cece3ea8f11533