### PR TITLE
Expire preloader cookie daily

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ async function init() {
 
     if (!getCookie('visited')) {
         showPreloader(debtData);
-        setCookie('visited', 'true', 365);
+        setCookie('visited', 'true', 1);
     } else {
         d3.select('#preloader').remove();
         d3.select('.container').style('opacity', '1');


### PR DESCRIPTION
## Summary
- expire the `visited` cookie after 24 hours so the preloader displays at most once per day

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a137dfe7483258ca4bc11984f830b