### PR TITLE
Display loading message before styles load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,10 +35,24 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+  <style>
+    #preloader {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #000;
+      color: #22c55e;
+      font-family: 'Press Start 2P', monospace;
+      z-index: 1000;
+    }
+    .container { opacity: 0; }
+  </style>
   <script defer src="bundle.js"></script>
 </head>
 <body>
-  <div id="preloader" class="fixed inset-0 bg-black opacity-0 z-[1000] hidden" aria-hidden="true"></div>
+  <div id="preloader" aria-hidden="true">Loading...</div>
   <div class="container">
     <header class="header mt-4 mb-4 flex justify-center items-center">
       <h1>The National Debt</h1>

--- a/src/preloader.js
+++ b/src/preloader.js
@@ -7,7 +7,7 @@ export function showPreloader(debtData) {
     const preloader = d3.select('#preloader');
     const container = d3.select('.container');
     container.style('opacity', '0');
-    preloader.style('display', 'block');
+    preloader.style('display', 'block').html('');
 
     const svg = preloader.append('svg')
         .attr('width', '100%')


### PR DESCRIPTION
## Summary
- hide main UI until scripts finish loading
- show simple "Loading..." screen without relying on bundled styles
- clear fallback text when running animated preloader

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a15c9c52883258ace28fe244790c8